### PR TITLE
fix convert guid to guid in case of Dapper.SqlMapper already converte…

### DIFF
--- a/Slapper.AutoMapper.Tests/GuidConverterTests.cs
+++ b/Slapper.AutoMapper.Tests/GuidConverterTests.cs
@@ -16,5 +16,19 @@ namespace Slapper.Tests.ConvertersTests
             // Act + Assert
             Assert.True(this.converter.CanConvert(null, targetType)); // Input value does not matter, null is enough for the test.
         }
+
+        [TestCase(typeof(Guid))]
+        [TestCase(typeof(Guid?))]
+        public void Can_Convert_Guid_To_Guid(Type targetType)
+        {
+            //Arrange
+            var guid = Guid.NewGuid();
+
+            // Act
+            var result = this.converter.Convert(guid, targetType);
+
+            //Assert
+            Assert.That( Equals(guid, result));
+        }
     }
 }

--- a/Slapper.AutoMapper/Slapper.AutoMapper.Configuration.cs
+++ b/Slapper.AutoMapper/Slapper.AutoMapper.Configuration.cs
@@ -1,30 +1,30 @@
 ﻿/*  Slapper.AutoMapper v1.0.0.6 ( https://github.com/SlapperAutoMapper/Slapper.AutoMapper )
 
     MIT License:
-   
+
     Copyright (c) 2016, Randy Burden ( http://randyburden.com ) and contributors. All rights reserved.
     All rights reserved.
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-    associated documentation files (the "Software"), to deal in the Software without restriction, including 
-    without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
-    copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the 
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+    associated documentation files (the "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
     following conditions:
 
-    The above copyright notice and this permission notice shall be included in all copies or substantial 
+    The above copyright notice and this permission notice shall be included in all copies or substantial
     portions of the Software.
 
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
-    LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN 
-    NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
-    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+    LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+    NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+    WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
     Description:
-    
+
     Slapper.AutoMapper maps dynamic data to static types. Slap your data into submission!
-    
-    Slapper.AutoMapper ( Pronounced Slapper-Dot-Automapper ) is a single file mapping library that can convert 
+
+    Slapper.AutoMapper ( Pronounced Slapper-Dot-Automapper ) is a single file mapping library that can convert
     dynamic data into static types and populate complex nested child objects.
     It primarily converts C# dynamics and IDictionary<string, object> to strongly typed objects and supports
     populating an entire object graph by using underscore notation to underscore into nested objects.
@@ -129,7 +129,7 @@ namespace Slapper
             }
 
             /// <summary>
-            /// Defines methods that can convert values from one type to another. 
+            /// Defines methods that can convert values from one type to another.
             /// </summary>
             public interface ITypeConverter
             {
@@ -170,18 +170,16 @@ namespace Slapper
                 /// <returns>Converted value.</returns>
                 public object Convert(object value, Type type)
                 {
-                    object convertedValue = null;
-
                     if (value is string)
-                    {
-                        convertedValue = new Guid(value as string);
-                    }
-                    if (value is byte[])
-                    {
-                        convertedValue = new Guid(value as byte[]);
-                    }
+                        return new Guid(value as string);
 
-                    return convertedValue;
+                    if (value is byte[])
+                        return new Guid(value as byte[]);
+
+                    if (value is Guid)
+                        return value;
+
+                    return null;
                 }
 
                 /// <summary>


### PR DESCRIPTION
We have faced an issue that GUID going to be null in case of using Uuid column in MSSQL database and Dapper
I assume the reason is some conversions inside Dapper.SqlMapper

For examle(QueryAsync from Dapper): 
```
class MyType { Guid? MyField {get;set;} }
dynamic data = await MyDbConnection.QueryAsync<dynamic>(template, param);
var result = Slapper.AutoMapper.MapDynamic<MyType>(data) as IEnumerable<MyType>;
```
All of "MyField" are null